### PR TITLE
Fix some missing common.props tags in .csproj files

### DIFF
--- a/src/Akka.CQRS.Infrastructure/Akka.CQRS.Infrastructure.csproj
+++ b/src/Akka.CQRS.Infrastructure/Akka.CQRS.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(NetStandardVersion)</TargetFramework>
     <Description>Shared, non-domain-specific infrastructure used by various Akka.CQRS services.</Description>
     <Configurations>Debug;Release;Phobos</Configurations>
   </PropertyGroup>
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster.Sharding" Version="$(AkkaVersion)-beta*" />
+    <PackageReference Include="Akka.Cluster.Sharding" Version="$(AkkaVersion)" />
     <PackageReference Include="Akka.Persistence.Extras" Version="$(AkkaPersistenceExtrasVersion)" />
     <PackageReference Include="Akka.Bootstrap.Docker" Version="$(AkkaBootstrapVersion)" />
   </ItemGroup>

--- a/src/Akka.CQRS.Pricing.Cli/Akka.CQRS.Pricing.Cli.csproj
+++ b/src/Akka.CQRS.Pricing.Cli/Akka.CQRS.Pricing.Cli.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(NetStandardVersion)</TargetFramework>
     <Description>Petabridge.Cmd palettes for accessing the pricing system.</Description>
     <Configurations>Debug;Release;Phobos</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Petabridge.Cmd.Host" Version="0.8.0" />
+    <PackageReference Include="Petabridge.Cmd.Host" Version="$(PetabridgeCmdVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some projects `TargetFramework` and package version tags need to be changed to use the `common.props` file.