### PR TITLE
Don't target `master` for dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,6 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "nuget"
-    target-branch: "master"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "nuget"
     target-branch: "start"
     directory: "/"
     schedule:


### PR DESCRIPTION
`master` should only be updated by merging `dev` with it once we're ready for a release.